### PR TITLE
arcd/Makefile: Fixes #90, use ${CURDIR} instead of ${PWD}

### DIFF
--- a/arcd/Makefile
+++ b/arcd/Makefile
@@ -13,7 +13,7 @@ TARGET=arcd
 # Prepend our _vendor directory to the system GOPATH
 # so that import path resolution will prioritize
 # our third party snapshots.
-GOPATH := ${PWD}/$(VENDOR_PATH):${GOPATH}
+GOPATH := ${CURDIR}/$(VENDOR_PATH):${GOPATH}
 export GOPATH
 
 default: build
@@ -55,7 +55,7 @@ vendor_update: vendor_get
 # installed in GOPATH since `go get` will use
 # that existing location as the destination.
 vendor_get: vendor_clean
-	GOPATH=${PWD}/$(VENDOR_PATH) go get -d -u -v $(DEPENDENCIES)
+	GOPATH=${CURDIR}/$(VENDOR_PATH) go get -d -u -v $(DEPENDENCIES)
 
 vendor_clean:
 	rm -dRf $(VENDOR_PATH)/src


### PR DESCRIPTION
PWD is not guaranteed to be passed to the Makefile
for example when a target task is executed with
sudo which sanitizes the ENV. It has also been
found as not being set with GNU Make running
on OpenBSD/amd64.

Instead we use ${CURDIR} which is set by GNU Make
itself and will work properly even with recursive
make calls.

see:
https://www.gnu.org/software/make/manual/html_node/Recursion.html

Signed-off-by: Adam Wolk <adam.wolk@tintagel.pl>